### PR TITLE
fix to two bugs in speciesTable and speciesLayers

### DIFF
--- a/Boreal_LBMRDataPrep.R
+++ b/Boreal_LBMRDataPrep.R
@@ -695,11 +695,9 @@ Save <- function(sim) {
                                userTags = c(cacheTags, "speciesLayers"))
 
     #options(opts)
-    speciesLayersList <- writeRaster(speciesLayersList,
+    sim$speciesLayers <- writeRaster(speciesLayersList,
                                      file.path(outputPath(sim), "speciesLayers.grd"),
                                      overwrite = TRUE)
-    
-    sim$speciesLayers <- speciesLayersList
   }
 
   # 3. species maps


### PR DESCRIPTION
speciesTable is called but the function mixes dPath with url and cacheTags with dpath. 
speciesLayers returns a rasterStack, and with no speciesLayersList$speciesLayers object, the writeRaster returns an error. 