### PR TITLE
age and B imputation fixes and new features

### DIFF
--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -1377,21 +1377,21 @@ Save <- function(sim) {
   ## Stand age map ------------------------------------------------
   if (!suppliedElsewhere("standAgeMap", sim)) {
     # httr::with_config(config = httr::config(ssl_verifypeer = 0L), {
-    out <- Cache(LandR::prepInputsStandAgeMap,
-                 destinationPath = dPath,
-                 ageURL = extractURL("standAgeMap"),
-                 studyArea = raster::aggregate(sim$studyAreaLarge),
-                 rasterToMatch = sim$rasterToMatchLarge,
-                 filename2 = .suffix("standAgeMap.tif", paste0("_", P(sim)$.studyAreaName)),
-                 overwrite = TRUE,
-                 fireURL = P(sim)$fireURL,
-                 fireField = "YEAR",
-                 startTime = start(sim),
-                 userTags = c("prepInputsStandAge_rtm", currentModule(sim), cacheTags),
-                 omitArgs = c("destinationPath", "targetFile", "overwrite",
-                              "alsoExtract", "userTags"))
-    sim$standAgeMap <- out$standAgeMap
-    sim$imputedPixID <- out$imputedPixID
+    sim$standAgeMap <- Cache(LandR::prepInputsStandAgeMap,
+                             destinationPath = dPath,
+                             ageURL = extractURL("standAgeMap"),
+                             studyArea = raster::aggregate(sim$studyAreaLarge),
+                             rasterToMatch = sim$rasterToMatchLarge,
+                             filename2 = .suffix("standAgeMap.tif", paste0("_", P(sim)$.studyAreaName)),
+                             overwrite = TRUE,
+                             fireURL = P(sim)$fireURL,
+                             fireField = "YEAR",
+                             startTime = start(sim),
+                             userTags = c("prepInputsStandAge_rtm", currentModule(sim), cacheTags),
+                             omitArgs = c("destinationPath", "targetFile", "overwrite",
+                                          "alsoExtract", "userTags"))
+    LandR::assertStandAgeMapAttr(sim$standAgeMap)
+    sim$imputedPixID <- attr(sim$standAgeMap, "imputedPixID")
     # })
   }
   ## Species equivalencies table -------------------------------------------

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -120,6 +120,8 @@ defineModule(sim, list(
                     "When assigning pixelGroup membership, this defines the resolution of ages that will be considered 'the same pixelGroup', e.g., if it is 10, then 6 and 14 will be the same"),
     defineParameter("pixelGroupBiomassClass", "numeric", 100, NA, NA,
                     "When assigning pixelGroup membership, this defines the resolution of biomass that will be considered 'the same pixelGroup', e.g., if it is 100, then 5160 and 5240 will be the same"),
+    defineParameter("rmImputedPix", "logical", FALSE, NA, NA,
+                    "Should sim$imputedPixID be removed from the simulation?"),
     defineParameter("speciesUpdateFunction", "list",
                     list(quote(LandR::speciesTableUpdate(sim$species, sim$speciesTable, sim$sppEquiv, P(sim)$sppEquivCol))),
                     NA, NA,
@@ -1028,10 +1030,15 @@ createBiomass_coreInputs <- function(sim) {
 
   ## make cohortDataFiles: pixelCohortData (rm unnecessary cols, subset pixels with B>0,
   ## generate pixelGroups, add ecoregionGroup and totalBiomass) and cohortData
-  cohortDataFiles <- Cache(makeCohortDataFiles, pixelCohortData, columnsForPixelGroups, speciesEcoregion,
+  cohortDataFiles <- Cache(makeCohortDataFiles,
+                           pixelCohortData = pixelCohortData,
+                           columnsForPixelGroups = sim$columnsForPixelGroups,
+                           speciesEcoregion = speciesEcoregion,
                            pixelGroupBiomassClass = P(sim)$pixelGroupBiomassClass,
                            pixelGroupAgeClass = P(sim)$pixelGroupAgeClass,
                            minAgeForGrouping = maxAgeHighQualityData,
+                           rmImputedPix = P(sim)$rmImputedPix,
+                           imputedPixID = sim$imputedPixID,
                            pixelFateDT = pixelFateDT)
 
   sim$cohortData <- cohortDataFiles$cohortData

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -1199,20 +1199,20 @@ Save <- function(sim) {
 
   if (!suppliedElsewhere("rawBiomassMap", sim) || needRTM) {
     # httr::with_config(config = httr::config(ssl_verifypeer = 0L), { ## TODO: re-enable verify
-      #necessary for KNN
-      sim$rawBiomassMap <- Cache(prepInputs,
-                                 url = extractURL("rawBiomassMap"),
-                                 destinationPath = dPath,
-                                 studyArea = sim$studyAreaLarge,   ## Ceres: makePixel table needs same no. pixels for this, RTM rawBiomassMap, LCC.. etc
-                                 rasterToMatch = if (!needRTM) sim$rasterToMatchLarge else NULL,
-                                 maskWithRTM = if (!needRTM) TRUE else FALSE,
-                                 useSAcrs = FALSE,     ## never use SA CRS
-                                 method = "bilinear",
-                                 datatype = "INT2U",
-                                 filename2 = .suffix("rawBiomassMap.tif", paste0("_", P(sim)$.studyAreaName)),
-                                 overwrite = TRUE,
-                                 userTags = c(cacheTags, "rawBiomassMap"),
-                                 omitArgs = c("destinationPath", "targetFile", "userTags", "stable"))
+    #necessary for KNN
+    sim$rawBiomassMap <- Cache(prepInputs,
+                               url = extractURL("rawBiomassMap"),
+                               destinationPath = dPath,
+                               studyArea = sim$studyAreaLarge,   ## Ceres: makePixel table needs same no. pixels for this, RTM rawBiomassMap, LCC.. etc
+                               rasterToMatch = if (!needRTM) sim$rasterToMatchLarge else NULL,
+                               maskWithRTM = if (!needRTM) TRUE else FALSE,
+                               useSAcrs = FALSE,     ## never use SA CRS
+                               method = "bilinear",
+                               datatype = "INT2U",
+                               filename2 = .suffix("rawBiomassMap.tif", paste0("_", P(sim)$.studyAreaName)),
+                               overwrite = TRUE,
+                               userTags = c(cacheTags, "rawBiomassMap"),
+                               omitArgs = c("destinationPath", "targetFile", "userTags", "stable"))
     # })
   }
 
@@ -1323,19 +1323,19 @@ Save <- function(sim) {
   ## Stand age map ------------------------------------------------
   if (!suppliedElsewhere("standAgeMap", sim)) {
     # httr::with_config(config = httr::config(ssl_verifypeer = 0L), {
-      sim$standAgeMap <- Cache(LandR::prepInputsStandAgeMap,
-                               destinationPath = dPath,
-                               ageURL = extractURL("standAgeMap"),
-                               studyArea = raster::aggregate(sim$studyAreaLarge),
-                               rasterToMatch = sim$rasterToMatchLarge,
-                               filename2 = .suffix("standAgeMap.tif", paste0("_", P(sim)$.studyAreaName)),
-                               overwrite = TRUE,
-                               fireURL = extractURL("fireURL"),
-                               fireField = "YEAR",
-                               startTime = start(sim),
-                               userTags = c("prepInputsStandAge_rtm", currentModule(sim), cacheTags),
-                               omitArgs = c("destinationPath", "targetFile", "overwrite",
-                                            "alsoExtract", "userTags"))
+    sim$standAgeMap <- Cache(LandR::prepInputsStandAgeMap,
+                             destinationPath = dPath,
+                             ageURL = extractURL("standAgeMap"),
+                             studyArea = raster::aggregate(sim$studyAreaLarge),
+                             rasterToMatch = sim$rasterToMatchLarge,
+                             filename2 = .suffix("standAgeMap.tif", paste0("_", P(sim)$.studyAreaName)),
+                             overwrite = TRUE,
+                             fireURL = extractURL("fireURL"),
+                             fireField = "YEAR",
+                             startTime = start(sim),
+                             userTags = c("prepInputsStandAge_rtm", currentModule(sim), cacheTags),
+                             omitArgs = c("destinationPath", "targetFile", "overwrite",
+                                          "alsoExtract", "userTags"))
     # })
   }
   ## Species equivalencies table -------------------------------------------

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -899,35 +899,35 @@ createBiomass_coreInputs <- function(sim) {
     message(blue("Subsetting to studyArea"))
     rasterToMatchLarge <- sim$rasterToMatchLarge
     rasterToMatchLarge <- setValues(rasterToMatchLarge, seq(ncell(rasterToMatchLarge)))
-    rasterToMatchLarge <- Cache(postProcess,
+    rasterToMatchLargeCropped <- Cache(postProcess,
                                 x = rasterToMatchLarge,
                                 rasterToMatch = sim$rasterToMatch,
                                 maskWithRTM = TRUE,
                                 filename2 = NULL,
                                 datatype = assessDataType(rasterToMatchLarge),
                                 #useCache = "overwrite",
-                                userTags = c(cacheTags, "rasterToMatchLarge"),
+                                userTags = c(cacheTags, "rasterToMatchLargeCropped"),
                                 omitArgs = c("userTags"))
 
-    assertthat::assert_that(sum(is.na(getValues(rasterToMatchLarge))) < ncell(rasterToMatchLarge)) ## i.e., not all NA
+    assertthat::assert_that(sum(is.na(getValues(rasterToMatchLargeCropped))) < ncell(rasterToMatchLargeCropped)) ## i.e., not all NA
 
-    if (!compareRaster(rasterToMatchLarge, sim$rasterToMatch, orig = TRUE, stopiffalse = FALSE))
+    if (!compareRaster(rasterToMatchLargeCropped, sim$rasterToMatch, orig = TRUE, stopiffalse = FALSE))
       stop("Downsizing to rasterToMatch after estimating parameters didn't work.",
            "Please debug Biomass_borealDataPrep::createBiomass_coreInputs().")
 
     ## subset pixels that are in studyArea/rasterToMatch only
-    pixToKeep <- na.omit(getValues(rasterToMatchLarge)) # these are the old indices of RTML
+    pixToKeep <- na.omit(getValues(rasterToMatchLargeCropped)) # these are the old indices of RTML
     pixelCohortData <- pixelCohortData[pixelIndex %in% pixToKeep]
 
     ## re-do pixelIndex (it now needs to match rasterToMatch)
-    newPixelIndexDT <- data.table(pixelIndex = getValues(rasterToMatchLarge),
-                                  newPixelIndex = as.integer(1:ncell(rasterToMatchLarge))) %>%
+    newPixelIndexDT <- data.table(pixelIndex = getValues(rasterToMatchLargeCropped),
+                                  newPixelIndex = as.integer(1:ncell(rasterToMatchLargeCropped))) %>%
       na.omit(.)
 
     pixelCohortData <- newPixelIndexDT[pixelCohortData, on = "pixelIndex"]
     pixelCohortData[, pixelIndex := NULL]
     setnames(pixelCohortData, old = "newPixelIndex", new = "pixelIndex")
-    rm(pixToKeep, rasterToMatchLarge)
+    rm(pixToKeep, rasterToMatchLargeCropped)
 
     assertthat::assert_that(NROW(pixelCohortData) > 0)
 

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -19,7 +19,7 @@ defineModule(sim, list(
                   "rasterVis", "ggplot2",
                   "sp", "sf", "merTools", "SpaDES.tools",
                   "PredictiveEcology/reproducible@development (>=1.2.6.9009)",
-                  "PredictiveEcology/LandR@development (>= 1.0.5)",
+                  "CeresBarros/LandR@ageBimputationFixes (>= 1.0.6)",
                   "PredictiveEcology/SpaDES.core@dotSeed (>=1.0.6.9016)",
                   "PredictiveEcology/pemisc@development"),
   parameters = rbind(

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -508,17 +508,18 @@ createBiomass_coreInputs <- function(sim) {
   # Make the initial pixelCohortData table
   #######################################################
   coverColNames <- paste0("cover.", sim$species$species)
-  out <- Cache(makeAndCleanInitialCohortData, pixelTable,
-               sppColumns = coverColNames,
-               imputeBadAgeModel = P(sim)$imputeBadAgeModel,
-               #pixelGroupBiomassClass = P(sim)$pixelGroupBiomassClass,
-               #pixelGroupAgeClass = P(sim)$pixelGroupAgeClass,
-               minCoverThreshold = P(sim)$minCoverThreshold,
-               doSubset = P(sim)$subsetDataAgeModel,
-               userTags = c(cacheTags, "pixelCohortData"),
-               omitArgs = c("userTags"))
-  pixelCohortData <- out$cohortData
-  sim$imputedPixID <- unique(c(sim$imputedPixID, out$imputedPixID))
+  pixelCohortData <- Cache(makeAndCleanInitialCohortData, pixelTable,
+                           sppColumns = coverColNames,
+                           imputeBadAgeModel = P(sim)$imputeBadAgeModel,
+                           #pixelGroupBiomassClass = P(sim)$pixelGroupBiomassClass,
+                           #pixelGroupAgeClass = P(sim)$pixelGroupAgeClass,
+                           minCoverThreshold = P(sim)$minCoverThreshold,
+                           doSubset = P(sim)$subsetDataAgeModel,
+                           userTags = c(cacheTags, "pixelCohortData"),
+                           omitArgs = c("userTags"))
+  assertCohortDataAttr(pixelCohortData)
+
+  sim$imputedPixID <- unique(c(sim$imputedPixID, attr(pixelCohortData, "imputedPixID")))
   pixelFateDT <- pixelFate(pixelFateDT, "makeAndCleanInitialCohortData rm cover < minThreshold",
                            tail(pixelFateDT$runningPixelTotal, 1) -
                              NROW(unique(pixelCohortData$pixelIndex)))

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -520,47 +520,56 @@ createBiomass_coreInputs <- function(sim) {
   if (isTRUE(P(sim)$fitDeciduousCoverDiscount)) {
     message(magenta(paste0(format(P(sim)$coverPctToBiomassPctModel, appendLF = FALSE))))
 
-    pixelCohortData[, lcc := as.factor(lcc)]
+    # pixelCohortData[, lcc := as.factor(lcc)]
+    #
+    # plot.it <- FALSE
+    # sam <- subsetDT(pixelCohortData, by = c("speciesCode", "lcc"),
+    #                 doSubset = P(sim)$subsetDataAgeModel,
+    #                 indices = TRUE)
+    # pi <- unique(pixelCohortData[sam]$pixelIndex)
+    # sam <- which(pixelCohortData$pixelIndex %in% pi)
+    #
+    # system.time({
+    #   out <- optimize(interval = c(0.1, 1), f = coverOptimFn, bm = P(sim)$coverPctToBiomassPctModel,
+    #                   pixelCohortData = pixelCohortData, subset = sam, maximum = FALSE)
+    # })
+    # params(sim)$Biomass_borealDataPrep$deciduousCoverDiscount <- out$minimum
+    #
+    # if (plot.it) {
+    #   cover2BiomassModel <- coverOptimFn(out$minimum, pixelCohortData, P(sim)$subsetDataAgeModel,
+    #                                      P(sim)$coverPctToBiomassPctModel, returnAIC = FALSE)
+    #   sam1 <- sample(NROW(pixelCohortData), 1e5)
+    #   dev()
+    #   par(mfrow = c(1,2))
+    #   plot(predict(cover2BiomassModel$modelBiomass1$mod,
+    #                newdata = cover2BiomassModel$pixelCohortData[sam1]),
+    #        log(cover2BiomassModel$pixelCohortData$B / 100)[sam1], pch = ".")
+    #   abline(a = 0, b = 1)
+    #
+    #   cover2BiomassModel1 <- coverOptimFn(1, pixelCohortData, P(sim)$subsetDataAgeModel,
+    #                                       P(sim)$coverPctToBiomassPctModel,
+    #                                       returnAIC = FALSE)
+    #   dev()
+    #   plot(predict(cover2BiomassModel1$modelBiomass1$mod,
+    #                newdata = cover2BiomassModel1$pixelCohortData[sam1]),
+    #        log(cover2BiomassModel1$pixelCohortData$B / 100)[sam1], pch = ".")
+    #   abline(a = 0, b = 1)
+    #
+    #   pcd <- pixelCohortData
+    #   bb <- pcd[sample(sam)]
+    #   cc <- bb[, cover3 := cover * c(1, out$minimum)[decid + 1]][
+    #     , actualX := cover3 / sum(cover3) / (cover / 100), by = "pixelIndex"]
+    #   setkey(cc, pixelIndex)
+    #   mean(cc[speciesCode == "Popu_Tre"]$actualX)
+    # }
 
-    plot.it <- FALSE
-    sam <- subsetDT(pixelCohortData, by = c("speciesCode", "lcc"),
-                    doSubset = P(sim)$subsetDataAgeModel,
-                    indices = TRUE)
-    pi <- unique(pixelCohortData[sam]$pixelIndex)
-    sam <- which(pixelCohortData$pixelIndex %in% pi)
+    params(sim)$Biomass_borealDataPrep$deciduousCoverDiscount <- Cache(deciduousCoverDiscountFun,
+                                                                       pixelCohortData = pixelCohortData,
+                                                                       coverPctToBiomassPctModel = P(sim)$coverPctToBiomassPctModel,
+                                                                       subsetDataAgeModel = P(sim)$subsetDataAgeModel,
+                                                                       userTags = c(cacheTags, "decidCoverDisc"),
+                                                                       omitArgs = c("userTags"))
 
-    system.time({
-      out <- optimize(interval = c(0.1, 1), f = coverOptimFn, bm = P(sim)$coverPctToBiomassPctModel,
-                      pixelCohortData = pixelCohortData, subset = sam, maximum = FALSE)
-    })
-    params(sim)$Biomass_borealDataPrep$deciduousCoverDiscount <- out$minimum
-    if (plot.it) {
-      cover2BiomassModel <- coverOptimFn(out$minimum, pixelCohortData, P(sim)$subsetDataAgeModel,
-                                         P(sim)$coverPctToBiomassPctModel, returnAIC = FALSE)
-      sam1 <- sample(NROW(pixelCohortData), 1e5)
-      dev()
-      par(mfrow = c(1,2))
-      plot(predict(cover2BiomassModel$modelBiomass1$mod,
-                   newdata = cover2BiomassModel$pixelCohortData[sam1]),
-           log(cover2BiomassModel$pixelCohortData$B / 100)[sam1], pch = ".")
-      abline(a = 0, b = 1)
-
-      cover2BiomassModel1 <- coverOptimFn(1, pixelCohortData, P(sim)$subsetDataAgeModel,
-                                          P(sim)$coverPctToBiomassPctModel,
-                                          returnAIC = FALSE)
-      dev()
-      plot(predict(cover2BiomassModel1$modelBiomass1$mod,
-                   newdata = cover2BiomassModel1$pixelCohortData[sam1]),
-           log(cover2BiomassModel1$pixelCohortData$B / 100)[sam1], pch = ".")
-      abline(a = 0, b = 1)
-
-      pcd <- pixelCohortData
-      bb <- pcd[sample(sam)]
-      cc <- bb[, cover3 := cover * c(1, out$minimum)[decid + 1]][
-        , actualX := cover3 / sum(cover3) / (cover / 100), by = "pixelIndex"]
-      setkey(cc, pixelIndex)
-      mean(cc[speciesCode == "Popu_Tre"]$actualX)
-    }
   } else {
     message(magenta(paste0(format(P(sim)$coverPctToBiomassPctModel, appendLF = FALSE))))
     message(blue("using previously estimated deciduousCoverDiscount:",

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -911,14 +911,14 @@ createBiomass_coreInputs <- function(sim) {
     rasterToMatchLarge <- sim$rasterToMatchLarge
     rasterToMatchLarge <- setValues(rasterToMatchLarge, seq(ncell(rasterToMatchLarge)))
     rasterToMatchLargeCropped <- Cache(postProcess,
-                                x = rasterToMatchLarge,
-                                rasterToMatch = sim$rasterToMatch,
-                                maskWithRTM = TRUE,
-                                filename2 = NULL,
-                                datatype = assessDataType(rasterToMatchLarge),
-                                #useCache = "overwrite",
-                                userTags = c(cacheTags, "rasterToMatchLargeCropped"),
-                                omitArgs = c("userTags"))
+                                       x = rasterToMatchLarge,
+                                       rasterToMatch = sim$rasterToMatch,
+                                       maskWithRTM = TRUE,
+                                       filename2 = NULL,
+                                       datatype = assessDataType(rasterToMatchLarge),
+                                       #useCache = "overwrite",
+                                       userTags = c(cacheTags, "rasterToMatchLargeCropped"),
+                                       omitArgs = c("userTags"))
 
     assertthat::assert_that(sum(is.na(getValues(rasterToMatchLargeCropped))) < ncell(rasterToMatchLargeCropped)) ## i.e., not all NA
 
@@ -938,12 +938,13 @@ createBiomass_coreInputs <- function(sim) {
     pixelCohortData <- newPixelIndexDT[pixelCohortData, on = "pixelIndex"]
     pixelCohortData[, pixelIndex := NULL]
     setnames(pixelCohortData, old = "newPixelIndex", new = "pixelIndex")
-    rm(pixToKeep, rasterToMatchLargeCropped)
 
     assertthat::assert_that(NROW(pixelCohortData) > 0)
 
     ## now convert imputedPixID to RTM
     sim$imputedPixID <- newPixelIndexDT[pixelIndex %in% sim$imputedPixID, newPixelIndex]
+
+    rm(pixToKeep, rasterToMatchLargeCropped, newPixelIndexDT)
     if (ncell(sim$rasterToMatch) > 3e6) replicate(10, gc())
   }
   ## subset ecoregionFiles$ecoregionMap to smaller area.

--- a/R/coverOptimFn.R
+++ b/R/coverOptimFn.R
@@ -1,3 +1,56 @@
+#' @importFrom crayon magenta
+deciduousCoverDiscountFun <- function(pixelCohortData,
+                                      coverPctToBiomassPctModel = quote(glm(I(log(B/100)) ~ logAge * I(log(totalBiomass/100)) * speciesCode * lcc)),
+                                      subsetDataAgeModel) {
+
+  message(magenta(paste0(format(coverPctToBiomassPctModel, appendLF = FALSE))))
+
+  pixelCohortData[, lcc := as.factor(lcc)]
+
+  plot.it <- FALSE
+  sam <- subsetDT(pixelCohortData, by = c("speciesCode", "lcc"),
+                  doSubset = subsetDataAgeModel,
+                  indices = TRUE)
+  pi <- unique(pixelCohortData[sam]$pixelIndex)
+  sam <- which(pixelCohortData$pixelIndex %in% pi)
+
+  system.time({
+    out <- optimize(interval = c(0.1, 1), f = coverOptimFn, bm = coverPctToBiomassPctModel,
+                    pixelCohortData = pixelCohortData, subset = sam, maximum = FALSE)
+  })
+
+  if (plot.it) {
+    cover2BiomassModel <- coverOptimFn(out$minimum, pixelCohortData, subsetDataAgeModel,
+                                       coverPctToBiomassPctModel, returnAIC = FALSE)
+    sam1 <- sample(NROW(pixelCohortData), 1e5)
+    dev()
+    par(mfrow = c(1,2))
+    plot(predict(cover2BiomassModel$modelBiomass1$mod,
+                 newdata = cover2BiomassModel$pixelCohortData[sam1]),
+         log(cover2BiomassModel$pixelCohortData$B / 100)[sam1], pch = ".")
+    abline(a = 0, b = 1)
+
+    cover2BiomassModel1 <- coverOptimFn(1, pixelCohortData, subsetDataAgeModel,
+                                        coverPctToBiomassPctModel,
+                                        returnAIC = FALSE)
+    dev()
+    plot(predict(cover2BiomassModel1$modelBiomass1$mod,
+                 newdata = cover2BiomassModel1$pixelCohortData[sam1]),
+         log(cover2BiomassModel1$pixelCohortData$B / 100)[sam1], pch = ".")
+    abline(a = 0, b = 1)
+
+    pcd <- pixelCohortData
+    bb <- pcd[sample(sam)]
+    cc <- bb[, cover3 := cover * c(1, out$minimum)[decid + 1]][
+      , actualX := cover3 / sum(cover3) / (cover / 100), by = "pixelIndex"]
+    setkey(cc, pixelIndex)
+    mean(cc[speciesCode == "Popu_Tre"]$actualX)
+  }
+  return(out$minimum)
+}
+
+
+
 #' @importFrom crayon cyan
 #' @importFrom LandR subsetDT asInteger
 #' @importFrom data.table setDT


### PR DESCRIPTION
These fixes require using ~`LandR@ageBimputationFixes`~ (now merged into `LandR@development`).

* `imputedPixID`  is a new `sim` object 
* `fireURL` is now a character parameter and has `sourceURL = NA`. Supplying NULL/NA in fireURL turns off age/B imputation inside fire perimeters 
* New parameter to turn on/off the removal of imputed pixels: `rmImputedPix`, defaults to FALSE. /!\ This means that pixels are imputed anyways, but may be removed or not from the simulation. 