### PR TITLE
Allow user to pass different rawBiomassMap, that will define RTM

### DIFF
--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -1393,6 +1393,15 @@ Save <- function(sim) {
     if (needRTML && !needRTM) {
       sim$rasterToMatchLarge <- sim$rasterToMatch
     } else if (needRTML && needRTM) {
+      if (!compareRaster(sim$rawBiomassMap, sim$studyAreaLarge, stopiffalse = FALSE)) {
+        ## note that extents may never align if the resolution and projection do not allow for it
+        sim$rawBiomassMap <- Cache(postProcessTerra,
+                                   sim$rawBiomassMap,
+                                   studyArea = sim$studyAreaLarge,
+                                   useSAcrs = TRUE,
+                                   overwrite = TRUE)
+        sim$rawBiomassMap <- fixErrors(sim$rawBiomassMap)
+      }
       sim$rasterToMatchLarge <- sim$rawBiomassMap
     }
 

--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -1351,7 +1351,7 @@ Save <- function(sim) {
     }
   }
 
-  if (!suppliedElsewhere("rawBiomassMap", sim) || needRTM) {
+  if (!suppliedElsewhere("rawBiomassMap", sim)) {
     # httr::with_config(config = httr::config(ssl_verifypeer = 0L), { ## TODO: re-enable verify
     #necessary for KNN
     if (P(sim)$dataYear == 2001) {


### PR DESCRIPTION
Before: if RTM (not RTMLarge, which was probably also a bug) was missing the `rawBiomassMap` would be overwritten (!)
This is a bug, in the sense that the user was prevented from passing a custom `rawBiomassMap`  to be used basis for RTMLarge (and consequently RTM).

I suggest:
- only looking at the existence of `rawBiomassMap` in `sim` to deermine if the default should be created and, then, use `rawBiomassMap` (whatever its origin) to make RTMLarge/RTM after checking that it matches SALarge