### PR TITLE
Remove unused, archived 'fasterize' from reqdPkgs

### DIFF
--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -20,7 +20,7 @@ defineModule(sim, list(
     before = c("Biomass_core")
   ),
   reqdPkgs = list(
-    "archive", "assertthat", "cli", "data.table", "dplyr", "fasterize",  "ggplot2", "httr2",
+    "archive", "assertthat", "cli", "data.table", "dplyr", "ggplot2", "httr2",
     "merTools", "plyr", "qs2", "rasterVis", "sf", "terra", "googledrive",
     "reproducible (>= 2.1.0)", "SpaDES.core (>= 2.1.0)", "SpaDES.tools (>= 2.0.0)",
     "PredictiveEcology/LandR@development (>= 1.1.5.9090)",


### PR DESCRIPTION
`fasterize` is declared in `reqdPkgs` but never used in the module (zero `fasterize::` calls -- rasterization is done via `terra`). Since `fasterize` was archived on CRAN (Oct 2023), this dead dependency now blocks installing the module's dependencies. This drops it (one line).

Verified: a repo-wide search finds `fasterize` only in the `reqdPkgs` entry, and the module parses unchanged after removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)