### PR TITLE
new parameter LCCClassesToReplaceNNMethod; require LandR (>= 1.2.0.9005)

### DIFF
--- a/Biomass_borealDataPrep.R
+++ b/Biomass_borealDataPrep.R
@@ -10,7 +10,7 @@ defineModule(sim, list(
     person(c("Alex", "M."), "Chubaty", email = "achubaty@for-cast.ca", role = c("aut"))
   ),
   childModules = character(0),
-  version = list(Biomass_borealDataPrep = "1.5.11"),
+  version = list(Biomass_borealDataPrep = "1.5.12"),
   timeframe = as.POSIXlt(c(NA, NA)),
   timeunit = "year",
   citation = list("citation.bib"),
@@ -23,7 +23,7 @@ defineModule(sim, list(
     "archive", "assertthat", "cli", "data.table", "dplyr", "ggplot2", "httr2",
     "merTools", "plyr", "qs2", "rasterVis", "sf", "terra", "googledrive",
     "reproducible (>= 2.1.0)", "SpaDES.core (>= 2.1.0)", "SpaDES.tools (>= 2.0.0)",
-    "PredictiveEcology/LandR@development (>= 1.1.5.9090)",
+    "PredictiveEcology/LandR@development (>= 1.2.0.9005)",
     "PredictiveEcology/pemisc@development",
     "PredictiveEcology/SpaDES.project@development (>= 0.0.8.9026)"
   ),
@@ -138,6 +138,16 @@ defineModule(sim, list(
                           "Since this is about estimating parameters for growth, it doesn't make any sense to have",
                           "unique estimates for transient classes in most cases. If no classes are to be replaced, pass",
                           "`'LCCClassesToReplaceNN' = numeric(0)` when supplying parameters.")),
+    defineParameter("LCCClassesToReplaceNNMethod", "character", "nearestRandom", NA, NA,
+                    paste("Passed to `LandR::convertUnwantedLCC()` as its `method` argument, controlling how",
+                          "each `P(sim)$LCCClassesToReplaceNN` pixel picks among the available classes in its",
+                          "neighbourhood. Both options weight the classes by their local abundance and differ",
+                          "only in reproducibility. `'nearestRandom'` (default) draws from the RNG, so",
+                          "replicates differ -- but note that `Cache()` does not key on RNG state, so a cached",
+                          "call replays a single draw unless the seed is part of the cache key.",
+                          "`'nearestWeighted'` instead keys the draw on the pixel's ground position, making it",
+                          "deterministic and seed-free, and giving the same answer on a grid-aligned crop of",
+                          "the study area as on the full extent. See `?LandR::convertUnwantedLCC`.")),
     defineParameter("minCoverThreshold", "numeric", 5, 0, 100,
                     "Pixels with total cover that is equal to or below this number will be omitted from the dataset"),
     defineParameter("minRelativeBFunction", "call", quote(LandR::makeMinRelativeB(pixelCohortData)),
@@ -835,14 +845,18 @@ createBiomass_coreInputs <- function(sim) {
     newLCCClasses <- convertUnwantedLCC(
       classesToReplace = P(sim)$LCCClassesToReplaceNN,
       rstLCC = rstLCCAdj,
-      availableERC_by_Sp = availableCombinations2
+      availableERC_by_Sp = availableCombinations2,
+      method = P(sim)$LCCClassesToReplaceNNMethod
     ) |>
       Cache(userTags = c(cacheTags, "newLCCClasses", "stable"))
     
     ## adjust rstLCCAdj so that ecoregionMap will contain the last set of updated LCCClassesToReplaceNN
     if (nrow(newLCCClasses)) {
       if (!is.null(newLCCClasses$newPossLCC)) {
-        ## LandR versions prior to 1.1.5.9045 will not have this
+        ## LandR versions prior to 1.1.5.9045 do not have this, and 1.2.0.9004 dropped it
+        ## again -- where this guard silently stopped firing, leaving rstLCCAdj (and so
+        ## ecoregionMap) showing the un-replaced classes. reqdPkgs now floors LandR at
+        ## 1.2.0.9005, which restored it.
         rstLCCAdj[newLCCClasses$pixelIndex] <- newLCCClasses$newPossLCC
       }
     }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 Known issues: <https://github.com/PredictiveEcology/Biomass_borealDataPrep/issues>
 
+version 1.5.12
+=============
+
+## dependency changes
+* requires `LandR (>= 1.2.0.9005)`, which added the `method` argument to
+  `convertUnwantedLCC()` and removed that function's deterministic lowest-class tie-break.
+  1.2.0.9004 had also dropped the `newPossLCC` column this module uses to write
+  replacement classes back into `rstLCCAdj`, where the `is.null()` guard silently stopped
+  firing and left `rstLCCAdj` (hence `ecoregionMap`) showing the un-replaced classes;
+  1.2.0.9005 restores it.
+
+## new features
+* new parameter `LCCClassesToReplaceNNMethod`, passed to `LandR::convertUnwantedLCC()` as
+  its `method`. Default `"nearestRandom"` preserves the stochastic allocation this module
+  has always had. `"nearestWeighted"` gives the same abundance weighting but keys the draw
+  on the pixel's ground position, so it is deterministic without a seed and a grid-aligned
+  crop of the study area agrees with the full extent.
+
 # Biomass_borealDataPrep 1.5.11 (2026-06-02)
 
 * New `landis` mode parameter (default `FALSE`): when enabled, the forested LCC classes are collapsed to a single class in `createBiomass_coreInputs()` (before `prepEcoregions`/`makePixelTable`) so `ecoregionGroup` is defined by ecoregion only, not ecoregion x LCC; `maxB`, `maxANPP`, and species establishment probability are then estimated per ecoregion, as expected by LANDIS-II Biomass Succession. Default `FALSE` preserves the standard ecoregion x LCC behaviour.


### PR DESCRIPTION
Exposes the `method` argument added to `LandR::convertUnwantedLCC()` in **PredictiveEcology/LandR#197** as a module parameter.

Depends on PredictiveEcology/LandR#197 — merge that first.

Targets `development` (not `main`, which is 128 commits behind it).

## New parameter

`LCCClassesToReplaceNNMethod`, passed straight through to `convertUnwantedLCC(method = )`. Both options allocate each `LCCClassesToReplaceNN` pixel a neighbouring class drawn in proportion to that class's abundance in the pixel's neighbourhood; they differ only in where the draw comes from:

| value | behaviour |
|---|---|
| `"nearestRandom"` (**default**) | draws from the RNG — preserves the stochastic allocation this module has always had |
| `"nearestWeighted"` | keys the draw on the pixel's ground position: deterministic, needs no `set.seed()`, stable under `Cache()`, and a grid-aligned crop of the study area gives the same answer as the full extent |

The default deliberately keeps existing behaviour. `"nearestWeighted"` is there for workflows that need reproducibility without seed management, or that develop on a cropped subset before scaling up.

## Why the LandR floor moves to 1.2.0.9005

Two reasons:

1. **`method` doesn't exist before it**, so an older LandR fails with a clear unused-argument error rather than silently ignoring the parameter.
2. **LandR 1.2.0.9004 dropped the `newPossLCC` column** used below to write replacement classes back into `rstLCCAdj`. The `is.null()` guard there silently stopped firing, leaving `rstLCCAdj` — and therefore `ecoregionMap` — showing the un-replaced classes. LandR#197 restores it; the comment now records the gap so the floor isn't lowered later without noticing.

## Context worth knowing

LandR 1.2.0.9004 briefly replaced this function's stochastic search with a deterministic nearest-class rule that broke distance ties to the **lowest land-cover class**. Ties turn out to be common — 35–41% of unwanted pixels on real landscapes — and because the Canada LCC codes run non-vegetated → non-forest vegetation → forest, that biased imputation systematically out of forest. Pooled over four real SCANFI+FAO landscapes, versus the previous implementation:

| class | cover type | old | 1.2.0.9004 rule |
|---:|---|---:|---:|
|  50 | shrubs     |  9.63% | **16.25% (1.69×)** |
| 220 | broadleaf  | 15.12% | **8.75% (0.58×)** |
| 230 | mixedwood  |  6.97% | **1.96% (0.28×)** |

Non-forest vegetation went 11.3% → 18.6% of replaced pixels — about one in fourteen pixels that would have been forest wasn't. For this module that is not cosmetic: a pixel imputed as shrubs or herbs carries no tree cohorts at all.

LandR#197 removed that rule. **Neither value of this parameter reintroduces it** — both weight by local abundance and land within 0.9–1.0× of the old algorithm on every cover type.

## Testing

- Module metadata parses; `SpaDES.core::moduleParams()` registers the new parameter and `moduleMetadata()` reports the bumped floor and version.
- Not yet exercised end-to-end — that needs LandR#197 merged and installed first.

## Related

- PredictiveEcology/Biomass_borealDataPrep#101 — `Cache()` does not key on RNG state, so under the `"nearestRandom"` default a cached call replays a single draw across replicates. Pre-existing: this call has always been stochastic and cached. Filed separately rather than folded in here, since fixing it changes caching behaviour.
- FOR-CAST/Biomass_borealDataPrep#1 — the fork-side counterpart, already merged, which defaults to `"nearestWeighted"` instead for the projects consuming that fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
